### PR TITLE
Update references to old URL

### DIFF
--- a/content/2015-11-11-steam-machines.md
+++ b/content/2015-11-11-steam-machines.md
@@ -52,7 +52,7 @@ It's still a risky play, and, I'd argue, one that's potentially riskier than par
 
 As an aside, you might think that being third-party would help you create the Steam Machine of your dreams, but as of the time of this writing, you can't even configure an Alienware machine to use SSD.  For a gaming machine.  No SSD.  What?  If you're like me, that's the first thing you'll want to upgrade.  I asked the Alienware rep over Twitter about it and got:
 
-![Image of Alienware blaming lack of consumer choice on SKU complexity](http://www.jonathanturner.org/images/alienware.png)
+![Image of Alienware blaming lack of consumer choice on SKU complexity](http://www.jntrnr.com/images/alienware.png)
 
 Again, likely something that will be fixed in time, but not the best initial experience and one that will turn-off some gamers from the Steam Machine idea.
 

--- a/content/2015-11-20-porting-csharp-nes-emu-to-rust.md
+++ b/content/2015-11-20-porting-csharp-nes-emu-to-rust.md
@@ -6,7 +6,7 @@ tags = [ "rust", "emulation" ]
 
 Many years ago, I created a [simple NES emulator in C#](http://jturner.tapetrade.net/sharpnes/index.html) using SDL and Mono.  For fun, I wanted to see what it would be like to port that emulator to Rust.  A couple weeks later, after poking on it on and off between packing for a move, I was able to [get it working](https://github.com/jntrnr/rustynes).
 
-![Image of Super Mario Bros 1 on emulator](http://www.jonathanturner.org/images/smb1.png)
+![Image of Super Mario Bros 1 on emulator](http://www.jntrnr.com/images/smb1.png)
 
 # What I did
 

--- a/content/2016-01-22-rust-and-blub-paradox.md
+++ b/content/2016-01-22-rust-and-blub-paradox.md
@@ -10,7 +10,7 @@ A few weeks ago, I read an [analysis of Rust, D, and Go](https://www.quora.com/W
 
 Having met Andrei and seen a few of his talks, I know that he likes to poke fun.  Still, let's take the bait.  Is his observation funny because it's a funny image or is it funny because there's an underlying truth to what he's saying?
 
-**EDIT:** thanks to all the responses to this post, I've written a follow-up on [where the Blub Paradox is wrong and where it's helpful](http://www.jonathanturner.org/2016/01/rethinking-the-blub-paradox.html).
+**EDIT:** thanks to all the responses to this post, I've written a follow-up on [where the Blub Paradox is wrong and where it's helpful](http://www.jntrnr.com/2016/01/rethinking-the-blub-paradox.html).
 
 **EDIT #2:** Wow, some people also seem to be taking this article as an attack on Andrei.  Not at all!  Like I said, I've chatted with him in person and he's very much the type that likes to say funny things, whether about himself or the wide array of programming languages.  I just took one of his quotes about Rust as a starting point and had fun with it and looked at what might be weird about Rust coming from other languages.
 
@@ -196,7 +196,7 @@ While it may not look like it at first, the above example uses the "bubbling" st
 
 The end result means that if if ```load_header``` ever has a problem when calling ```file.read_u32()```, that Error will be returned instead.  If it is, the same thing happens in ```load_audio```, meaning that it, too, will return the same Error.  And so on, until the calling function finally handles the error case.  
 
-I wrote a [post about ```try!```](http://www.jonathanturner.org/2015/11/learning-to-try-things-in-rust.html), if you'd like to learn more.
+I wrote a [post about ```try!```](http://www.jntrnr.com/2015/11/learning-to-try-things-in-rust.html), if you'd like to learn more.
 
 # Weird feature #3: the borrow-checker
 

--- a/content/2016-01-23-rethinking-the-blub-paradox.md
+++ b/content/2016-01-23-rethinking-the-blub-paradox.md
@@ -4,7 +4,7 @@ title = "Feature Bias, or Rethinking the Blub Paradox"
 tags = [ "philosophy" ]
 +++
 
-I got a lot of great feedback on my previous post ["Rust and the Blub Paradox"](http://www.jonathanturner.org/2016/01/rust-and-blub-paradox.html), which inspired me to write a follow-up.
+I got a lot of great feedback on my previous post ["Rust and the Blub Paradox"](http://www.jntrnr.com/2016/01/rust-and-blub-paradox.html), which inspired me to write a follow-up.
 
 In its original formulation, the [Blub Paradox](http://www.paulgraham.com/avg.html) is something of a tool for people to feel smug about their favorite language.  I heard a lot of feedback that it feels condescending.  I hadn't realized that in my mind the Blub Paradox had morphed from its original form into something different.
 

--- a/content/2018-07-28-snapshot-of-rust-popularity.md
+++ b/content/2018-07-28-snapshot-of-rust-popularity.md
@@ -131,7 +131,7 @@ _Rust meetups now total over 130 around the world_
 
 The in-person piece of the Rust community, the Rust meetups, have seen 30% growth in the last nine months and now total over 130 around the world.  We've likewise seen steady growth in the number of conferences that users can attend for more training and networking.
 
-We've also seen some impressive growth in indicators of the online community as well since the [last time I reported on them](http://www.jonathanturner.org/2017/10/fun-facts-about-rust-growth.html). For example, the Rust reddit recently passed 40k users (up from the 29k of nine months ago), the GitHub repo is nearly at 30k stars (up from 24k), and the official Rust twitter has over 31k followers (up from 24k).
+We've also seen some impressive growth in indicators of the online community as well since the [last time I reported on them](http://www.jntrnr.com/2017/10/fun-facts-about-rust-growth.html). For example, the Rust reddit recently passed 40k users (up from the 29k of nine months ago), the GitHub repo is nearly at 30k stars (up from 24k), and the official Rust twitter has over 31k followers (up from 24k).
 
 This enthusiasm has also translated into the teams that govern Rust itself. Combined, the governing teams have doubled in size in the last 9 months to over [100 positions across the various teams](https://www.rust-lang.org/en-US/team.html). The scope has also grown in tandem, with new teams that cover infrastructure, developer experiences, and dependency management.
 

--- a/content/2019-08-23-introducing-nushell.md
+++ b/content/2019-08-23-introducing-nushell.md
@@ -10,7 +10,7 @@ It's called Nushell, or just Nu for short.  We have a [book](https://book.nushel
 
 This release was made by Jonathan Turner (me), Yehuda Katz, and Andrés Robalino, with contributions from Odin Dutton.
 
-![Nu in action](http://jonathanturner.org/images/nushell-autocomplete4.gif)
+![Nu in action](http://jntrnr.com/images/nushell-autocomplete4.gif)
 
 # But why?
 
@@ -24,19 +24,19 @@ In this post, I'll talk about how a few simple ideas drive how Nu works, what Nu
 
 To Nu, everything is data.  When you type `ls`, you're given a table of information about the directory you're listing:
 
-![ls command](http://jonathanturner.org/images/nu_ls.png)
+![ls command](http://jntrnr.com/images/nu_ls.png)
 
 Rather than having to remember different flags to `ls`, we can just work with the data it gives back. We can find the files greater than a certain size:
 
-![ls with filtering](http://jonathanturner.org/images/nu_ls_filter.png)
+![ls with filtering](http://jntrnr.com/images/nu_ls_filter.png)
 
 Or we could choose to sort it by a column, or only show directories, or more. That by itself is fun but perhaps not compelling enough.
 
-![ps with filtering](http://jonathanturner.org/images/nu_ps_filter.png)
+![ps with filtering](http://jntrnr.com/images/nu_ps_filter.png)
 
 Where this simple concept - that everything in Nu is data - starts to shine when we try other commands and realize that we're using the same commands to filter, to sort, etc. Rather than having the need to remember all the parameters to all the commands, we can just use the same verbs to act over our data, regardless of where the data came from.  Nu pushes this idea even further.
 
-![opening toml file](http://jonathanturner.org/images/open_cargo.png)
+![opening toml file](http://jntrnr.com/images/open_cargo.png)
 
 Nu also understands structured text files like JSON, TOML, YAML, and more. Opening these files gives us the same tables we saw with `ls` and `ps`. Again, this lets us use the same commands to filter our data, explore it, and use it.
 
@@ -212,19 +212,19 @@ You can see that we can mix-and-match commands that are inside of Nu with those 
 
 As we built Nu, we realized we could experiment with other parts of how a shell works. The first of these experiments lead us to an observation: if everything is data in Nu, we should be able to view this data.
 
-![viewing source file](http://jonathanturner.org/images/view_source.png)
+![viewing source file](http://jntrnr.com/images/view_source.png)
 
 We've seen the tables. Nu also supports opening and looking at text and binary data. If we open a source file, we can scroll around in a syntax-highlighted file. If we open an xml, we can look at its data. We can even open a binary file and look at what's inside (hint: there's even a fun easter egg if you open certain kinds binary files, especially if you've installed Nu with the optional `rawkey` feature).
 
 Being able to view data is helpful, and this kind of polish extends to other aspects, like error messages:
 
-![simple error](http://jonathanturner.org/images/nu_error2.png)
+![simple error](http://jntrnr.com/images/nu_error2.png)
  
 Nu takes heavy inspiration from the [error messages in Rust](https://blog.rust-lang.org/2016/08/10/Shape-of-errors-to-come.html). As much as possible, draw your eyes to the problem. 
 
 Combined with the pipeline, some pretty interesting errors are possible:
 
-![error with metadata](http://jonathanturner.org/images/nu_error_metadata.png)
+![error with metadata](http://jntrnr.com/images/nu_error_metadata.png)
 
 You might wonder how does that even work. Nu has a metadata system (still early!) that you can read about in the [Metadata chapter](https://book.nushell.sh/en/metadata) of the [Nu book](https://book.nushell.sh). Let's just take a quick peek at it:
 

--- a/content/2019-09-24-nushell_0_3_0.md
+++ b/content/2019-09-24-nushell_0_3_0.md
@@ -16,11 +16,11 @@ Nu 0.3.0 is available as [pre-built binaries](https://github.com/nushell/nushell
 
 ## New table design (Porges, jntrnr)
 
-![Table with utf8 box drawing](http://jonathanturner.org/images/utf8_table.png)
+![Table with utf8 box drawing](http://jntrnr.com/images/utf8_table.png)
 
 One of the most striking differences is that Nu now uses UTF-8 box drawing to draw its tables. 
 
-![Table with utf8 box drawing in light mode](http://jonathanturner.org/images/utf8_light_table.png)
+![Table with utf8 box drawing in light mode](http://jntrnr.com/images/utf8_light_table.png)
 
 The table is also configurable. If you feel like the table is a bit too heavy, you can also configure it to work in light mode using this command:
 
@@ -48,7 +48,7 @@ Since the 0.2.0 release, Nu has gained a set of additional commands, including:
 
 ## Error improvements (jntrnr)
 
-![Improve error messages](http://jonathanturner.org/images/did_you_mean.png)
+![Improve error messages](http://jntrnr.com/images/did_you_mean.png)
 
 We've made steady progress on improving error messages. Recently, we added "did you mean?" errors to help when you mistype the name of columns. Nu 0.3.0 also has gone through a few passes to generally polish the errors to include more information when an error occurs.
 

--- a/content/2019-10-15-nushell-0_4_0.md
+++ b/content/2019-10-15-nushell-0_4_0.md
@@ -16,14 +16,14 @@ Nu 0.4.0 is available as [pre-built binaries](https://github.com/nushell/nushell
 
 ## New Colors (wycats)
 
-![The prompt with the latest colors](http://jonathanturner.org/images/0_4_0_new_colors.png)
+![The prompt with the latest colors](http://jntrnr.com/images/0_4_0_new_colors.png)
 New colors!
 
 With 0.4.0, we're adding some new colors to show off different types of the command, where errors might be happening, and if the command is internal or external. The coloring is just the tip of the iceberg, as it were, and builds from a reworking of the parser to make it more accurate, more stable, and more feature-complete.
 
 ## Streaming table (jntrnr)
 
-![Animation of a long table streaming out](http://jonathanturner.org/images/0_4_0_streaming_table.gif)
+![Animation of a long table streaming out](http://jntrnr.com/images/0_4_0_streaming_table.gif)
 Streaming tables
 
 Up to this point, we've taken a few shortcuts with how streams worked in Nushell.  We knew that a table, in theory, was a stream of rows. In practice, though, this wasn't the case as the code has lots of assumptions about how tables worked.

--- a/content/2021-03-03-retiring.md
+++ b/content/2021-03-03-retiring.md
@@ -20,7 +20,7 @@ I've been enjoying working on the [Rust beginner series](https://www.youtube.com
 
 ## Work on the Rust intermediate series
 
-I recently [asked on Twitter](https://twitter.com/jntrnr/status/1358592787852140550?s=20) about intermediate Rust content, which inspired me to start an intermediate Rust series. You can find out more information [on this series in this blog post](http://www.jonathanturner.org/intermedia-rust-series/).
+I recently [asked on Twitter](https://twitter.com/jntrnr/status/1358592787852140550?s=20) about intermediate Rust content, which inspired me to start an intermediate Rust series. You can find out more information [on this series in this blog post](http://www.jntrnr.com/intermedia-rust-series/).
 
 ## Keep doing Systems with JT
 

--- a/static/poems/waitingtogrow/poems.markdown
+++ b/static/poems/waitingtogrow/poems.markdown
@@ -4,7 +4,7 @@ Waiting to Grow
 Introduction
 --------------------------------
 
-_Waiting to Grow_ is a collection of poems by [Jonathan Turner](https://jonathanturner.org). 
+_Waiting to Grow_ is a collection of poems by [Jonathan Turner](https://jntrnr.com). 
 
 Please enjoy.
 


### PR DESCRIPTION
Hi there! 👋 I hope you're having a fantastic day!

I read your post this afternoon, [Introducing nushell](https://www.jntrnr.com/introducing-nushell/), and noticed that the images weren't loading:

<img width="854" alt="image" src="https://user-images.githubusercontent.com/784253/141660342-c01366a5-10dc-458d-9b5f-d08df11af7bb.png">

I saw that a little over a month ago (efe7e5280a47b2af4b56285dd62bb5e703430472...ca7e5f3adefcda7209785815589e33b75f041681), the site's URL was updated to `www.jntrnr.com`, but that references to the old URL haven't been updated yet. I put together this small PR to update all of those references, thinking it might be helpful, but I'm also not 100% sure I did things correctly 🤷 I ran

```
$ zola serve
```

locally, and things appear to be working as expected now:

<img width="834" alt="image" src="https://user-images.githubusercontent.com/784253/141660487-9af41076-3edb-4cb1-adb0-ca2b8ac5b3d5.png">

---

P.S. I really enjoy your YouTube videos and blog! Thank you for everything you do!! 😄 